### PR TITLE
Fix "{type: 'dismiss' }" android bug, which results even after successful authentication

### DIFF
--- a/AzureADGraph.js
+++ b/AzureADGraph.js
@@ -43,7 +43,7 @@ const callMsGraph = async (token) => {
     graphResponse = response;
   })
   .catch((error) => {
-    console.error(error);
+    graphResponse = error;
   });
   return graphResponse;
 }; //end callMsGraph()
@@ -126,7 +126,6 @@ const openAuthSession = async (props) => {
     Else, proceed with grabbing a token for authentication.
   */
   if (authResponse.type || authResponse == undefined) {
-    console.log("hiiiii")
     return { "error"    : authResponse.errorCode  || "Canceled operation."};
   } 
 
@@ -136,7 +135,6 @@ const openAuthSession = async (props) => {
   the parameters will be defined if the authorization session continues. 
   */
   if ( authResponse && authResponse.params.code != undefined) {
-    console.log("authResponse.params.code");
     return await getToken(authResponse.params.code, props);
   } 
 

--- a/AzureADGraph.js
+++ b/AzureADGraph.js
@@ -116,20 +116,36 @@ const openAuthSession = async (props) => {
         https://docs.expo.io/versions/latest/sdk/auth-session/#authsessionstartasyncoptions
   */ 
   
- let authResponse = await AuthSession.startAsync({
-    authUrl     :   authUrl,
-    returnUrl   :   props.redirectUrl || AuthSession.makeRedirectUri()
-  });
+  let authResponse = await AuthSession.startAsync({
+      authUrl     :   authUrl,
+      returnUrl   :   props.redirectUrl || AuthSession.makeRedirectUri()
+    });
 
   /* 
     If there is an error, return the error code. 
     Else, proceed with grabbing a token for authentication.
   */
-  if (authResponse.type && authResponse.type === 'error') {
-      return { "error"    : authResponse.errorCode };
-  } else {
+  if (authResponse.type || authResponse == undefined) {
+    console.log("hiiiii")
+    return { "error"    : authResponse.errorCode  || "Canceled operation."};
+  } 
+
+  /*
+  Only continue with the authentication process if user does not cancel or close 
+  the ongoing authentication window or session. authResponse and the code from 
+  the parameters will be defined if the authorization session continues. 
+  */
+  if ( authResponse && authResponse.params.code != undefined) {
+    console.log("authResponse.params.code");
     return await getToken(authResponse.params.code, props);
-  }
+  } 
+
+  //Fallback else statement for any other errors.
+  else {
+    return { 
+      "error": "Unknown error."
+    };
+  }  
 }; //end openAuthSession()
 
 export { openAuthSession };

--- a/AzureADGraph.js
+++ b/AzureADGraph.js
@@ -125,8 +125,8 @@ const openAuthSession = async (props) => {
     If there is an error, return the error code. 
     Else, proceed with grabbing a token for authentication.
   */
-  if (authResponse.type && authResponse.type === 'error' ) {
-      return { error    : authResponse.errorCode };
+  if (authResponse.type && authResponse.type === 'error') {
+      return { "error"    : authResponse.errorCode };
   } else {
     return await getToken(authResponse.params.code, props);
   }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "expo-auth-session": "^1.2.1"
   },
   "name": "azure-ad-graph-expo",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Small library designed for use with Expo, for getting user data from the Microsoft Graph API, using Azure AD for authentication, and following the Microsoft Azure AD auth flow.  AzureADGraph is not a react component.",
   "main": "AzureADGraph.js",
   "devDependencies": {},

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "expo-auth-session": "^1.2.1"
   },
   "name": "azure-ad-graph-expo",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Small library designed for use with Expo, for getting user data from the Microsoft Graph API, using Azure AD for authentication, and following the Microsoft Azure AD auth flow.  AzureADGraph is not a react component.",
   "main": "AzureADGraph.js",
   "devDependencies": {},


### PR DESCRIPTION
Supply a returnUrl parameter to the AuthSession.startAsync() config object. This patches a strange bug on Android; the authentication result would always be { type: dismiss } prior to this. Add a conditional to return an errorcode if there is indeed an error present. Full authentication working on Android devices now. 