### PR TITLE
Update dependencies versions in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
-    "expo": "^37.0.12",
-    "expo-auth-session": "^1.2.1"
+    "expo": "^48.0.19",
+    "expo-auth-session": "^4.0.3"
   },
   "name": "azure-ad-graph-expo",
   "version": "2.1.0",


### PR DESCRIPTION
Updating Expo and Expo-Auth-Session to the latest version.

By keeping the older versions (in which @unimodules still is a dependency) expo-doctor will keep giving warnings.